### PR TITLE
Fix: Ensure Blender renders are saved using absolute file paths

### DIFF
--- a/demo/render_hints.py
+++ b/demo/render_hints.py
@@ -1,3 +1,4 @@
+import os
 import multiprocessing
 import tempfile
 from multiprocessing import Process
@@ -48,7 +49,7 @@ def render_hint_images(model_path, fov, pls, power=500., geo_smooth=True, output
 
             # and png
             bpy.context.scene.render.image_settings.file_format = 'PNG'
-            bpy.context.scene.render.filepath = f'{output_path}{mat_name}.png'
+            bpy.context.scene.render.filepath = os.path.abspath(f'{output_path}{mat_name}.png')
             bpy.ops.render.render(animation=False, write_still=True)
 
     # Render hints


### PR DESCRIPTION
Use absolute file paths instead of relative when specifying the output directory for rendered images. Relative paths can led to issues where rendered images were not saved as expected because Blender relative path might be different (tested on windows)
C:\tmp\prov_img_id... and not in the tmp\prov_img_id which was created relatively by the project dir.
Blender render wont throw exception, but it will place the images into different folder so infer_img.py fails (line 119 no such file). This fixed for me, please consider adding, as it won't break anything and absolute path can be more robust especially considering other platforms, thank you. 
ps: amazing project, by far the best I found for long time!

